### PR TITLE
remove unnecessary is_null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+#### Changed
+- Remove unnecessary is_null()
+
 #### Fixed
 - Log info message about successful authentication only after successful authentication to SP
 

--- a/lib/Auth/Process/DatabaseCommand.php
+++ b/lib/Auth/Process/DatabaseCommand.php
@@ -43,7 +43,7 @@ class DatabaseCommand
         $month = $date->format('m');
         $day = $date->format('d');
 
-        if (is_null($idpEntityID) || empty($idpEntityID) || is_null($spEntityId) || empty($spEntityId)) {
+        if (empty($idpEntityID) || empty($spEntityId)) {
             Logger::error(
                 "Some from attribute: 'idpEntityId', 'idpName', 'spEntityId' and 'spName'" .
                 " is null or empty and login log wasn't inserted into the database."
@@ -58,7 +58,7 @@ class DatabaseCommand
                 Logger::error("The login log wasn't inserted into table: " . $statisticsTableName . ".");
             }
 
-            if (!is_null($idpName) && !empty($idpName)) {
+            if (!empty($idpName)) {
                 $stmt->prepare(
                     "INSERT INTO " . $identityProvidersMapTableName .
                     "(entityId, name) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = ?"
@@ -67,7 +67,7 @@ class DatabaseCommand
                 $stmt->execute();
             }
 
-            if (!is_null($spName) && !empty($spName)) {
+            if (!empty($spName)) {
                 $stmt->prepare(
                     "INSERT INTO " . $serviceProvidersMapTableName .
                     "(identifier, name) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = ?"

--- a/templates/idpDetail-tpl.php
+++ b/templates/idpDetail-tpl.php
@@ -36,7 +36,7 @@ $this->data['head'] .= '<meta name="translations" id="translations" content="'.h
 
 $idpName = DatabaseCommand::getIdPNameByEntityId($idpEntityId);
 
-if (!is_null($idpName) && !empty($idpName)) {
+if (!empty($idpName)) {
     $this->data['header'] = $this->t('{proxystatistics:Proxystatistics:templates/idpDetail_header_name}') . $idpName;
 } else {
     $this->data['header'] = $this->t('{proxystatistics:Proxystatistics:templates/idpDetail_header_entityId}') .

--- a/templates/spDetail-tpl.php
+++ b/templates/spDetail-tpl.php
@@ -35,7 +35,7 @@ $this->data['head'] .= '<meta name="translations" id="translations" content="'.h
 
 $spName = DatabaseCommand::getSpNameBySpIdentifier($spIdentifier);
 
-if (!is_null($spName) && !empty($spName)) {
+if (!empty($spName)) {
     $this->data['header'] = $this->t('{proxystatistics:Proxystatistics:templates/spDetail_header_name}') .
         $spName;
 } else {


### PR DESCRIPTION
From [PHP manual](https://www.php.net/manual/en/function.empty.php):

The following values are considered to be empty:

- `""` (an empty string)
- `0` (0 as an integer)
- `0.0` (0 as a float)
- `"0"` (0 as a string)
- `NULL`
- `FALSE`
- `array()` (an empty array)