### PR TITLE
fix: Fix migration script for MySQL

### DIFF
--- a/scripts/migrate_v6_mysql.sql
+++ b/scripts/migrate_v6_mysql.sql
@@ -1,9 +1,9 @@
-ALTER TABLE statistics_sums CHANGE idpId idp_id INT UNSIGNED NOT NULL DEFAULT 0;
-ALTER TABLE statistics_sums CHANGE spId sp_id INT UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE statistics_sums CHANGE idpId idp_id INT UNSIGNED NOT NULL;
+ALTER TABLE statistics_sums CHANGE spId sp_id INT UNSIGNED NOT NULL;
 
-ALTER TABLE statistics_per_user CHANGE idpId idp_id INT UNSIGNED NOT NULL DEFAULT 0;
-ALTER TABLE statistics_per_user CHANGE spId sp_id INT UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE statistics_per_user CHANGE idpId idp_id INT UNSIGNED NOT NULL;
+ALTER TABLE statistics_per_user CHANGE spId sp_id INT UNSIGNED NOT NULL;
 
-ALTER TABLE statistics_idp CHANGE idpId idp_id INT UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE statistics_idp CHANGE idpId idp_id INT UNSIGNED NOT NULL;
 
-ALTER TABLE statistics_sp CHANGE spId sp_id INT UNSIGNED NOT NULL DEFAULT 0;
+ALTER TABLE statistics_sp CHANGE spId sp_id INT UNSIGNED NOT NULL;


### PR DESCRIPTION
Adding default = 0 for ID columns breaks inserts. Insert will assign the default value as ID, therefore it will fail. That then results in UPDATE being executed, resulting in constant overwriting of the IDP/SP name.